### PR TITLE
Crunch a few hundred more bytes with cleaner code

### DIFF
--- a/fixi.js
+++ b/fixi.js
@@ -1,71 +1,73 @@
 (()=>{
-	let send = (elt, type, detail, bub)=>elt.dispatchEvent(new CustomEvent("fx:" + type, {detail, cancelable:true, bubbles:bub !== false, composed:true})),
-			attr = (elt, name, defaultVal)=>elt.getAttribute(name) ?? defaultVal,
-			ignore = elt=>!!elt.closest("[fx-ignore]"),
-			init = elt=>{
-		let options = {}
-		if (elt.__fixi || ignore(elt) || !send(elt, "init", {options})) return
-		elt.__fixi = async(evt)=>{
-			let reqs = elt.__fixi.requests ||= new Set()
-			let action = attr(elt, "fx-action")
-			let method = attr(elt, "fx-method", "GET").toUpperCase()
-			let targetSelector = attr(elt, "fx-target")
-			let target = targetSelector ? document.querySelector(targetSelector) : elt
-			let swap = attr(elt, "fx-swap", "outerHTML")
-			let form = elt.form || elt.closest("form")
-			let body = new FormData(form || undefined, evt.submitter)
+	let init = elt=>{
+		let options = {},
+				send = (type, detail, bubbles=true)=>elt.dispatchEvent(new CustomEvent("fx:" + type, {detail, cancelable:true, bubbles, composed:true})),
+				attr = (name, defaultVal)=>elt.getAttribute('fx-'+name) ?? defaultVal
+		if (elt.__fixi || elt.closest("[fx-ignore]") || !send("init", {options})) return
+		elt.__fixi = async evt=>{
+			let reqs = elt.__fixi.requests ??= new Set(),
+					form = elt.form ?? elt.closest("form"),
+					body = new FormData(form ?? undefined, evt.submitter),
+					abort = new AbortController()
 			if (!form && elt.name) body.append(elt.name, elt.value)
-			let drop = reqs.length > 0
-			let headers = {"FX-Request":"true"}
-			let abort = new AbortController()
-			let cfg = {trigger:evt, action, method, target, swap, body, drop, headers, abort:(r)=>abort.abort(r),
-				signal:abort.signal, preventTriggerDefault:true, transition:document.startViewTransition?.bind(document), fetch:fetch.bind(window)}
-			if (!send(elt, "config", {evt, cfg, requests:reqs}) || cfg.drop) return
+			let cfg = {
+				trigger: evt, 
+				action: attr("action"), 
+				method: attr("method", "GET").toUpperCase(), 
+				target: document.querySelector(attr("target")) ?? elt, 
+				swap: attr("swap", "outerHTML"), 
+				body, 
+				drop: reqs.length > 0, 
+				headers: {"FX-Request":true}, 
+				abort: r=>abort.abort(r), 
+				signal: abort.signal, 
+				preventTriggerDefault: true,
+				transition: document.startViewTransition?.bind(document),
+				fetch: fetch.bind(window)
+			}
+			if (!send("config", {evt, cfg, requests:reqs}) || cfg.drop) return
 			if (/GET|DELETE/.test(cfg.method)){
-				if (!cfg.body.entries().next().done) cfg.action += (cfg.action.indexOf("?") > 0 ? "&" : "?") + new URLSearchParams(cfg.body).toString()
+				if (!cfg.body.entries().next().done) cfg.action += '?&'[cfg.action.includes("?")] + new URLSearchParams(cfg.body).toString()
 				cfg.body = null
 			}
 			if (cfg.preventTriggerDefault) evt.preventDefault()
 			reqs.add(cfg)
 			try {
 				if (cfg.confirm && !await cfg.confirm()) return
-				if (!send(elt, "before", {evt, cfg, requests:reqs})) return
+				if (!send("before", {evt, cfg, requests:reqs})) return
 				cfg.response = await cfg.fetch(cfg.action, cfg)
 				cfg.text = await cfg.response.text()
-				if (!send(elt, "after", {evt, cfg})) return
+				if (!send("after", {evt, cfg})) return
 			} catch(error) {
-				send(elt, "error", {evt, cfg, error})
-				return
+				return send("error", {evt, cfg, error})
 			} finally {
 				reqs.delete(cfg)
-				send(elt, "finally", {evt, cfg})
+				send("finally", {evt, cfg})
 			}
 			let doSwap = ()=>{
-				if (cfg.swap instanceof Function)
-					return cfg.swap(cfg)
-				else if (/(before|after)(start|end)/.test(cfg.swap))
-					cfg.target.insertAdjacentHTML(cfg.swap, cfg.text)
-				else if(cfg.swap in cfg.target)
-					cfg.target[cfg.swap] = cfg.text
+				if (cfg.swap instanceof Function) cfg.swap(cfg)
+				else if (/(before|after)(start|end)/.test(cfg.swap)) cfg.target.insertAdjacentHTML(cfg.swap, cfg.text)
+				else if(cfg.swap in cfg.target) cfg.target[cfg.swap] = cfg.text
 				else throw cfg.swap
 			}
 			await (cfg.transition || doSwap)(doSwap)?.finished
-			send(elt, "swapped", {cfg})
+			send("swapped", {cfg})
 		}
-		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
-		elt.addEventListener(elt.__fixi.evt, elt.__fixi, options)
-		send(elt, "inited", {}, false)
+		elt.addEventListener(
+			elt.__fixi.evt = attr("trigger", elt.matches("form") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click"), 
+			elt.__fixi, options)
+		send("inited", {}, false)
 	}
 	let process = elt=>{
-		if (elt instanceof Element && !ignore(elt)){
+		if (elt instanceof Element){
 			if (elt.matches("[fx-action]")) init(elt)
-			elt.querySelectorAll("[fx-action]").forEach(elt=>init(elt))
+			elt.querySelectorAll("[fx-action]").forEach(init)
 		}
 	}
 	document.addEventListener("fx:process", evt=>process(evt.target))
 	document.addEventListener("DOMContentLoaded", ()=>{
-		document.__fixi_mo = new MutationObserver(recs=>recs.forEach(r=>r.type === "childList" && r.addedNodes.forEach(process)))
-		document.__fixi_mo.observe(document.body, {childList:true, subtree:true})
+		(document.__fixi_mo = new MutationObserver(recs=>recs.forEach(r=>r.type === "childList" && r.addedNodes.forEach(process))))
+			.observe(document.body, {childList:true, subtree:true})
 		process(document.body)
 	})
 })()


### PR DESCRIPTION
Totally up to you whether to include these changes, I had fun doing them either way ^^
- Moved `send` and `attr` inside to grab `elt` via closure instead of constantly passing it
- Moved variable definitions only ever used to define `cfg` into `cfg`'s object literal
- Shorthanded some overly verbose conditional branches and defaults
- Removed the `ignore` helper since it was only used in two places and one was redundant
- All tests pass

```
raw: 2909
gzipped: 1318
brotlid: 1113

raw.min: 2139
gzipped.min: 1135
brotlid.min: 951
```