### PR TITLE
fix examples in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ document.addEventListener("fx:init", (evt)=>{
       disableTarget.disabled = true
       evt.target.addEventListener('fx:after', (afterEvt)=>{
         if (afterEvt.target == evt.target){
-          disableTarget.disabled = true
+          disableTarget.disabled = false
         }
       })
     })
@@ -742,7 +742,7 @@ document.addEventListener("fx:init", (evt)=>{
   #indicator {
     display: none;
   }
-  #indicator .fixi-request-in-flight {
+  #indicator.fixi-request-in-flight {
     display: inline-block;
   }
 </style>


### PR DESCRIPTION
Was playing around with the examples from the readme and I think I found 2 errors:

1. In the "disable element extension" the element is not enabled after the request ends
2. In the "request indicator extension" the css selector is targeting a child of the target and not the target

Fixi is amazing, really love this project <3 