### PR TITLE
fix beforebegin and afterbegin swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can get support for fixi via:
 </tr>
 <tr>
 <td><code>fx-swap</code></td>
-<td>A string specifying how the content should be swapped into the DOM, can be one of <code>innerHTML</code>, <code>outerHTML</code>, <code>beforestart</code>, <code>afterstart</code>, <code>beforeend</code>, <code>afterend</code>, or any valid property on the element (e.g. `className` or `value`), defaults to  <code>outerHTML</code></td>
+<td>A string specifying how the content should be swapped into the DOM, can be one of <code>innerHTML</code>, <code>outerHTML</code>, <code>beforebegin</code>, <code>afterbegin</code>, <code>beforeend</code>, <code>afterend</code>, or any valid property on the element (e.g. `className` or `value`), defaults to  <code>outerHTML</code></td>
 <td><code>fx-swap=&#39;innerHTML&#39;</code></td>
 </tr>
 <tr>

--- a/fixi.js
+++ b/fixi.js
@@ -57,7 +57,7 @@
 			let doSwap = ()=>{
 				if (cfg.swap instanceof Function)
 					return cfg.swap(cfg)
-				else if (/(before|after)(start|end)/.test(cfg.swap))
+				else if (/(before|after)(begin|end)/.test(cfg.swap))
 					cfg.target.insertAdjacentHTML(cfg.swap, cfg.text)
 				else if(cfg.swap in cfg.target)
 					cfg.target[cfg.swap] = cfg.text

--- a/test.html
+++ b/test.html
@@ -228,6 +228,21 @@
         </div>
 
         <div class="test">
+            <h3>Test basic button with beforebegin swap works</h3>
+            <script>
+                test(async ()=>{
+                    mock("/demo", "<div>Foo</div>");
+                    find('button').click();
+                    await sleep(50);
+                    assertEq(find('button')?.previousElementSibling?.innerText, "Foo", true);
+                })
+            </script>
+            <button fx-action="/demo" fx-method="get" fx-swap="beforebegin">
+                Button 1
+            </button>
+        </div>
+
+        <div class="test">
             <h3>Test added content is live</h3>
             <script>
               test(async ()=>{


### PR DESCRIPTION
Fixed beforebegin and afterbegin swaps. See docs for accepted `position` values: https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML