### PR TITLE
Fix ext-fx-push example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ fixi does not implement history support, but you can add rudimentary support lik
         initJS();
     });
     document.addEventListener("fx:after", (evt)=>{
-        if (evt.target.getAttribute("ext-fx-push")){
+        if (evt.target.hasAttribute("ext-fx-push")){
             history.replaceState({fixi:true, url:location.href}, "", location.href)
             history.pushState({fixi:true, url:evt.detail.cfg.response.url}, "", evt.detail.cfg.response.url)
         }


### PR DESCRIPTION
Replace getAttribute with hasAttribute to work as expected. 

For example, in

```html
<a fx-action="/example" fx-target="#main" ext-fx-push>...</a>
```

will not replace the history because `ext-fx-push` has no value (`getAttribute`), although it is present (`hasAttribute`).