### PR TITLE
Fix `"find"` in Relative Selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,7 +959,7 @@ document.addEventListener('fx:config', (evt)=>{
     if (target.indexOf("closest ") == 0){
         evt.detail.cfg.target = evt.target.closest(target.substring(8))
     } else if (target.indexOf("find ") == 0){
-        evt.detail.cfg.target = evt.target.closest(target.substring(5))
+        evt.detail.cfg.target = evt.target.querySelector(target.substring(5))
     } else if (target.indexOf("next ") == 0){
         var matches = Array.from(document.querySelectorAll(target.substring(5)))
         evt.detail.cfg.target = matches.find((elt) => evt.target.compareDocumentPosition(elt) === Node.DOCUMENT_POSITION_FOLLOWING)


### PR DESCRIPTION
`"closest"` looks up (towards ancestors)

`"find"` looks down (towards descendants), right?

They both looked up because the code
used `closest(...)` in both branches.