### PR TITLE
Fix buttons do not add their value

### DIFF
--- a/fixi.js
+++ b/fixi.js
@@ -11,7 +11,7 @@
 			let reqs = elt.__fixi.requests ||= new Set()
 			let form = elt.form || elt.closest("form")
 			let body = new FormData(form ?? undefined, evt.submitter)
-			if (!form && elt.name) body.append(elt.name, elt.value)
+			if (elt.name && elt.hasAttribute("value")) body.append(elt.name, elt.value)
 			let ac = new AbortController()
 			let cfg = {
 				trigger:evt,


### PR DESCRIPTION
At the moment fixi does not submit the value of the button, if fix is triggered via a button.

```
<button fx-action="/content" <!-- URL to issue request to -->
        fx-method="get"      <!-- HTTP Method to use -->
        fx-trigger="click"   <!-- Event that triggers the request -->
        fx-target="#output"  <!-- Element to swap -->
        fx-swap="innerHTML"
        name="action"
        value="myValue"
        > <!-- How to swap -->
    Get Content
</button>
<output id="output"></output>
```
I am not sure, why the condtion of !form was added, but I think, it should be removed.