### PR TITLE
[Issue #32] Add button as submitter outside of submit event

### DIFF
--- a/fixi.js
+++ b/fixi.js
@@ -10,7 +10,7 @@
 		elt.__fixi = async(evt)=>{
 			let reqs = elt.__fixi.requests ||= new Set()
 			let form = elt.form || elt.closest("form")
-			let body = new FormData(form ?? undefined, evt.submitter)
+			let body = new FormData(form ?? undefined, evt.submitter ?? (form && form === elt.form && elt?.matches('input,button') && elt.type === "submit" ? elt : undefined))
 			if (!form && elt.name) body.append(elt.name, elt.value)
 			let ac = new AbortController()
 			let cfg = {


### PR DESCRIPTION
Currently if an fx-action is added to a button within a form, the button is not used as the form's submitter and will not be included in the formdata.

This checks if the triggering element is a valid submitter and includes it into the formdata if so.

In this example when clicking the button, butName=butVal will not be included in the formdata, since it is no proper submit (fx-trigger defaults to click) and thus does not have a submitter.
```html
<!DOCTYPE html>
<html>
	
<head>
	<script src="https://cdn.jsdelivr.net/gh/bigskysoftware/fixi@0.9.2/fixi.js"
        crossorigin="anonymous"
        integrity="sha256-0957yKwrGW4niRASx0/UxJxBY/xBhYK63vDCnTF7hH4="></script>

	<script>
	document.addEventListener('fx:before', function beforeFetch(evt,cfg) {
		for(const key of evt.detail.cfg.body.keys()){ 
			console.log(key);
		}
});
	</script>
</head>
<body>
	<form>
		<input type="hidden" name="hidName" value="hidVal"/>
		<button fx-action="/index.php" fx-method="POST" fx-target="#output" fx-swap="innerHTML" name="butName" value="butVal">Click here</button>
	</form>
	<div id="output">
		
	</div>
</body>
</html>
```