### PR TITLE
[Issue #32] Update to use standard submitters

### DIFF
--- a/fixi.js
+++ b/fixi.js
@@ -70,7 +70,7 @@
 			send(elt, "swapped", {cfg})
 			if (!document.contains(elt)) send(document, "swapped", {cfg})
 		}
-		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
+		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form,form button:not([type=button]):not([type=reset]),form input:is([type=submit],[type=image]") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
 		elt.addEventListener(elt.__fixi.evt, elt.__fixi, options)
 		send(elt, "inited", {}, false)
 	}

--- a/fixi.js
+++ b/fixi.js
@@ -70,7 +70,7 @@
 			send(elt, "swapped", {cfg})
 			if (!document.contains(elt)) send(document, "swapped", {cfg})
 		}
-		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form,button:not([type=button]):not([type=reset]),input:is([type=submit],[type=image]") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
+		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form,button:form not([type=button]):not([type=reset]),form input:is([type=submit],[type=image]") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
 		elt.addEventListener(elt.__fixi.evt, elt.__fixi, options)
 		send(elt, "inited", {}, false)
 	}

--- a/fixi.js
+++ b/fixi.js
@@ -70,7 +70,7 @@
 			send(elt, "swapped", {cfg})
 			if (!document.contains(elt)) send(document, "swapped", {cfg})
 		}
-		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form,form button:not([type=button]):not([type=reset]),form input:is([type=submit],[type=image]") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
+		elt.__fixi.evt = attr(elt, "fx-trigger", elt.matches("form,button:not([type=button]):not([type=reset]),input:is([type=submit],[type=image]") ? "submit" : elt.matches("input:not([type=button]),select,textarea") ? "change" : "click")
 		elt.addEventListener(elt.__fixi.evt, elt.__fixi, options)
 		send(elt, "inited", {}, false)
 	}


### PR DESCRIPTION
Issue: #32
Competing PRs: #33 #34
Difference from PRS: Correct issue early by setting "submit" event to elt.__fixi.evt and fx-trigger
Outcome: Native default behavior for form submissions (eg form button click includes name and value on send).

Native Form Submit Buttons https://developer.mozilla.org/en-US/docs/Glossary/Submit_button:

- `<button>` (its default type is "submit")
- `<input type="submit">`
- `<input type="image">`

Add CSS selectors for forms to pick submit event:

- If form button doesn't have type button and reset then it is a submit event. (Can't do type=submit since no attribute is often specified.)
- If form input  has type submit or image then it is a submit event.